### PR TITLE
Make browser "recording" notification go away after recording is stopped

### DIFF
--- a/WebAudioTrack.js
+++ b/WebAudioTrack.js
@@ -155,6 +155,9 @@
             this.microphoneSource.disconnect();
             this.jsAudioNode.disconnect();
 
+            // stop all MediaStream tracks to make the browser's recording indicator disappear
+            this.microphoneStream.getTracks().forEach(track => { track.stop() });
+            
             mergeLeftRightBuffers({
                 sampleRate: this.sampleRate,
                 numberOfAudioChannels: this.numberOfAudioChannels,

--- a/WebAudioTrack.js
+++ b/WebAudioTrack.js
@@ -156,7 +156,9 @@
             this.jsAudioNode.disconnect();
 
             // stop all MediaStream tracks to make the browser's recording indicator disappear
-            this.microphoneStream.getTracks().forEach(track => { track.stop() });
+            this.microphoneStream.getTracks().forEach(function(track) {
+              track.stop();
+            });
             
             mergeLeftRightBuffers({
                 sampleRate: this.sampleRate,


### PR DESCRIPTION
Browsers are required by the getUserMedia spec to indicate to the user when audio is being recorded. The desktop versions of Chrome and Firefox implement this as a red icon in the current browser tab. Chrome for Android implements it as a notification on the user's lock screen.

Currently with WebAudioTrack, the indicator remains active after recording is finished. This could give users the perception that a site is keeping the microphone active for the purpose of eavesdropping on them.

This patch provides a fix. It might have sufficed to use `this.microphoneStream.getTracks()[0].stop()` instead, but I thought I'd err on the safe side and just close all open tracks.