### PR TITLE
Recording does not work on Chrome M71

### DIFF
--- a/WebAudioTrack.js
+++ b/WebAudioTrack.js
@@ -127,6 +127,7 @@
             if (callback) {
                 this.initCallback = callback;
             }
+            this.context.resume();
 
             this.isCaptureInProgress = true;
 


### PR DESCRIPTION
New [Autoplay policy,](https://developers.google.com/web/updates/2017/09/autoplay-policy-changes#mei) prevents recording as AudioContext goes to suspended state.
